### PR TITLE
Add support for Integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: ci
 
 on:
-- pull_request
-- push
+  pull_request:
+  push:
+  repository_dispatch:
+    types: [integration-tests]
 
 jobs:
   test:
@@ -30,8 +32,15 @@ jobs:
           node-version: "21.1"
 
     steps:
+    - name: Set EXPRESS_BRANCH_NAME
+      run: echo "EXPRESS_BRANCH_NAME=${{ github.event.client_payload.branch || 'master' }}" >> $GITHUB_ENV
+
     - uses: actions/checkout@v3
 
+    - name: Replace Expressjs branch name in package.json
+      run: |
+        jq '.dependencies.express = "git+https://github.com/expressjs/express.git#'${EXPRESS_BRANCH_NAME}'"' package.json > temp.json && mv temp.json package.json
+    
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
       run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-session": "2.0.0",
         "ejs": "3.1.9",
         "eslint": "8.36.0",
-        "express": "4.18.2",
+        "express": "git+https://github.com/expressjs/express.git#master",
         "express-session": "1.17.2",
         "hbs": "4.2.0",
         "marked": "0.7.0",
@@ -975,6 +975,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/body-parser": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1711,12 +1734,12 @@
     },
     "node_modules/express": {
       "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "resolved": "git+ssh://git@github.com/expressjs/express.git#2a00da2067b7017f769c9100205a2a5f267a884b",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -1774,43 +1797,6 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3647,6 +3633,20 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "private": true,
   "homepage": "http://expressjs.com/",
   "dependencies": {
-    "express": "4.18.2",
+    "express": "git+https://github.com/expressjs/express.git#master",
     "after": "0.8.2",
     "connect-redis": "3.4.2",
     "cookie-parser": "1.4.6",


### PR DESCRIPTION

### Main Changes

- use expressjs directly from a GitHub (95902ff). By default we will be using `master` branch, just to keep in the latest (even unpublished changes)
- convert CI pipeline to express integration tests (3cc30a2). This pipeline can be executed from the Express repo directly. It will allow to specify the express.js branch used.

**Usage example**

```yml
name: Integration Tests

on: [push]

jobs:
  dispatch:
    runs-on: ubuntu-latest
    steps:
      - name: Repository Dispatch
        uses: peter-evans/repository-dispatch@v1
        with:
          repository: expressjs/examples
          event-type: integration-tests
          client-payload: '{"branch": "${{ github.head_ref || github.ref }}"}'
```

### Changelog

- 95902ff feat: use expressjs directly from a GitHub by @UlisesGascon
- 3cc30a2 feat: convert CI pipeline to express integration tests by @UlisesGascon
