### PR TITLE
Add support for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,17 @@ jobs:
     steps:
     - name: Set EXPRESS_BRANCH_NAME
       run: echo "EXPRESS_BRANCH_NAME=${{ github.event.client_payload.branch || 'master' }}" >> $GITHUB_ENV
+    
+    - name: Set EXPRESS_REPO
+      run: echo "EXPRESS_REPO=${{ github.event.client_payload.repo || 'expressjs/express' }}" >> $GITHUB_ENV 
 
     - uses: actions/checkout@v3
 
     - name: Replace Expressjs branch name in package.json
       run: |
-        jq '.dependencies.express = "git+https://github.com/expressjs/express.git#'${EXPRESS_BRANCH_NAME}'"' package.json > temp.json && mv temp.json package.json
-    
+        jq '.dependencies.express = "git+https://github.com/'${EXPRESS_REPO}'.git#'${EXPRESS_BRANCH_NAME}'"' package.json > temp.json && mv temp.json package.json
+        echo "Express dependency: $(jq -r '.dependencies.express' package.json)"
+
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
       run: |


### PR DESCRIPTION
### Main Changes

This changes enables the option to use forks of Express as dependency and not just branches as before.

### Changelog

- 9c09b4d feat: add support for forks by @UlisesGascon
